### PR TITLE
fix: occasional SearchFailed

### DIFF
--- a/lib/root.zig
+++ b/lib/root.zig
@@ -113,8 +113,8 @@ pub const ParseProblem = union(enum) {
                 if (p.expected.len > 0) try w.writeAll(", expected ");
                 for (p.expected, 0..) |e, i| {
                     try w.print("{f}", .{e});
-                    if (i < p.expected.len - 2) try w.writeAll(", ");
-                    if (i == p.expected.len - 2) try w.writeAll(" or ");
+                    if (i + 2 < p.expected.len) try w.writeAll(", ");
+                    if (i + 2 == p.expected.len) try w.writeAll(" or ");
                 }
             },
             .invalid_csharp_identifier => |p| w.print("Invalid C# identifier '{s}'", .{p.token.asSlice()}),
@@ -263,8 +263,8 @@ pub const RuntimeProblem = union(enum) {
                 if (p.expected.len > 0) try w.writeAll(", expected ");
                 for (p.expected, 0..) |e, i| {
                     try w.print("{t}", .{e});
-                    if (i < p.expected.len - 2) try w.writeAll(", ");
-                    if (i == p.expected.len - 2) try w.writeAll(" or ");
+                    if (i + 2 < p.expected.len) try w.writeAll(", ");
+                    if (i + 2 == p.expected.len) try w.writeAll(" or ");
                 }
             },
             .invalid_argument_count => |p| {

--- a/lib/runtime/ObjIterator.zig
+++ b/lib/runtime/ObjIterator.zig
@@ -48,26 +48,27 @@ pub fn next(self: *This) IterateError!?Entry {
     const zone = tracy.Zone(@src());
     defer zone.End();
 
-    var reader = &self.freader.interface;
-
     var target: usize = 0;
     if (self.last) |lst| {
         target = lst.info.pos + lst.info.len;
         self.freeLast();
     }
-    try self.freader.seekTo(target);
+    if (self.freader.logicalPos() != target) {
+        try self.freader.seekTo(target);
+    }
 
-    const info = findNextComponent(&self.freader) catch |err| switch (err) {
+    var out = std.Io.Writer.Allocating.init(self.allocator);
+    defer out.deinit();
+
+    const info = fetchNext(&self.freader, &out.writer) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
         error.EndOfStream => return null,
-        else => return err,
+        else => |e| return e,
     };
+    std.debug.assert(info.len == out.written().len);
 
-    try self.freader.seekTo(info.pos);
-    const content = try reader.readAlloc(self.allocator, info.len);
-    std.debug.assert(content.len == info.len);
-
-    self.last = .{ .info = info, .content = content };
-    return .{ .info = info, .content = content };
+    self.last = .{ .info = info, .content = try out.toOwnedSlice() };
+    return self.last;
 }
 
 fn freeLast(self: *This) void {
@@ -77,54 +78,58 @@ fn freeLast(self: *This) void {
     }
 }
 
-fn findNextComponent(freader: *std.fs.File.Reader) !Info {
+/// Fetches the next object definition from `freader`.
+/// The yaml document is written to `out` while the object information is returned.
+///
+/// The seek position must be initially located at the start
+/// of an object header or yaml directive.
+fn fetchNext(freader: *std.fs.File.Reader, out: *std.Io.Writer) !Info {
     const zone = tracy.Zone(@src());
     defer zone.End();
 
     var reader = &freader.interface;
-    var line: []u8 = &.{};
+    const head = while (true) { // search for next obj header
+        const ln = try reader.takeDelimiterInclusive('\n');
+        if (ln.len == 0 or ln[0] == '%') continue; // skip %YAML %TAG and empty lines
+        if (std.mem.startsWith(u8, ln, "--- !u!")) break ln;
 
-    while (true) { // search for next obj instance header
-        var peek: std.Io.Reader.DelimiterError![]u8 = reader.peekDelimiterInclusive('\n');
-        while (peek == error.StreamTooLong) { // skip long lines
-            _ = try reader.discardDelimiterInclusive('\n');
-            peek = reader.peekDelimiterInclusive('\n');
-        }
-        const p = peek catch |e| return e;
-        if (p[0] != '%' and !std.mem.startsWith(u8, p, "--- ")) break;
-        line = try reader.takeDelimiterInclusive('\n');
-    }
+        log.err("Expected obj header, found \"{s}\"", .{ln});
+        return error.InvalidHeader;
+    };
 
-    const header = try parseHeader(line);
-    const index = freader.logicalPos();
-    while (true) { // read until next obj instance header
-        line = reader.takeDelimiterInclusive('\n') catch |err| switch (err) {
-            error.EndOfStream => return .{ // return rest if doesnt find next obj instance header
-                .pos = index,
-                .len = freader.logicalPos() - index,
-                .class_id = @enumFromInt(header[0]),
-                .file_id = header[1],
-                .stripped = header[2],
+    const pos = freader.logicalPos();
+    const cid, const fid, const strp = parseHeader(head) catch |err| {
+        log.err("Invalid parseHeader(\"{s}\") close to pos {d}", .{ head, pos });
+        return err;
+    };
+
+    while (true) { // read until next header or eof
+        const ln = reader.peekDelimiterInclusive('\n') catch |err| switch (err) {
+            error.EndOfStream => {
+                _ = try reader.streamRemaining(out);
+                break;
             },
             error.StreamTooLong => { // skip long lines
-                _ = try reader.discardDelimiterInclusive('\n');
+                _ = try reader.streamDelimiter(out, '\n');
+                try reader.streamExact(out, 1);
                 continue;
             },
-            else => return err,
+            else => |e| return e,
         };
-        if (std.mem.startsWith(u8, line, "--- ")) break; // break if header
+        if (std.mem.startsWith(u8, ln, "--- !u!")) break; // break if header
+        try reader.streamExact(out, ln.len);
     }
 
     return .{
-        .pos = index,
-        .len = freader.logicalPos() - line.len - index,
-        .class_id = @enumFromInt(header[0]),
-        .file_id = header[1],
-        .stripped = header[2],
+        .pos = pos,
+        .len = freader.logicalPos() - pos,
+        .class_id = @enumFromInt(cid),
+        .file_id = fid,
+        .stripped = strp,
     };
 }
 
-fn parseHeader(line: []const u8) !struct { u32, core.runtime.FileID, bool } {
+fn parseHeader(line: []const u8) ParseHeaderError!struct { u32, core.runtime.FileID, bool } {
     var rdr: std.Io.Reader = .fixed(std.mem.trimRight(u8, line, "\r\n"));
 
     var buf: []u8 = rdr.take(7) catch return error.InvalidHeader;

--- a/lib/stmt/Rename.zig
+++ b/lib/stmt/Rename.zig
@@ -16,7 +16,6 @@ const yaml = core.yaml;
 old_name: Token,
 new_name: Token,
 of: clse.Of,
-in: ?clse.In,
 
 pub fn parse(tokens: *TokenIterator, env: Stmt.ParseEnv) Stmt.ParseError!This {
     const zone = tracy.Zone(@src());
@@ -32,7 +31,6 @@ pub fn parse(tokens: *TokenIterator, env: Stmt.ParseEnv) Stmt.ParseError!This {
 
     const Clauses = struct {
         OF: clse.Of,
-        IN: ?clse.In = null,
     };
     const clauses = try clse.parse(Clauses, tokens, env);
 
@@ -40,7 +38,6 @@ pub fn parse(tokens: *TokenIterator, env: Stmt.ParseEnv) Stmt.ParseError!This {
         .old_name = old_name,
         .new_name = new_name,
         .of = clauses.OF,
-        .in = clauses.IN,
     };
 }
 
@@ -58,7 +55,7 @@ pub fn run(self: This, env: Stmt.RunEnv) Stmt.RunError!void {
     const show = core.Stmt.Show{
         .mode = .indirect_uses,
         .of = self.of,
-        .in = self.in,
+        .in = clse.In.default,
         .where = null,
     };
 

--- a/src/help.txt
+++ b/src/help.txt
@@ -7,7 +7,7 @@ Usage:
 
 Options:
     --file <files...>  Specify one or more files to execute
-    --output <file>    Specify the file to output to
+    --out <file>       Specify the file to output to
     --check            Validates the code without running
     --                 Executes script through the stdin
     <queries...>       Run the specified queries
@@ -17,7 +17,7 @@ Examples:
     usrl "RENAME _spd FOR _speed OF Player" "EVAL _speed OF Player"
     usrl --file ./script.usrl ./script2.usrl
     usrl "SHOW uses OF Player" -f ./script.usrl
-    usrl "SHOW uses OF Player" --output ./log.txt
+    usrl "SHOW uses OF Player" --out ./log.txt
     usrl help
     usrl manual
     usrl interactive


### PR DESCRIPTION
This PR refactors the fetch function from `ObjIterator` to fix the occasional `error.SearchFailed` due to overriding the memory slice that contained the header during object iteration, causing it to return `error.InvalidHeader`.

This PR also:
- Fixes integer overflow when printing `RuntimeProblem.unexpected_type` or `ParseProblem.unexpected_token`.
- Removes the `IN` clause from the `RENAME` statement.
- Updates help message to use `--out` instead of `--output`